### PR TITLE
Automated Changelog Entry for 0.2.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,35 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.1
+
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-link-share/compare/0.2.0...a9ab3dde03285a7b8597ceb1e26412bcf01bebca))
+
+### Maintenance and upkeep improvements
+
+- Adopt Jupyter Packaging 0.10 and the releaser [#16](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/16) ([@jtpio](https://github.com/jtpio))
+
+### Other merged PRs
+
+- Bump tar from 6.1.5 to 6.1.11 [#15](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/15) ([@dependabot](https://github.com/dependabot))
+- Bump url-parse from 1.5.1 to 1.5.3 [#14](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/14) ([@dependabot](https://github.com/dependabot))
+- Bump path-parse from 1.0.6 to 1.0.7 [#13](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/13) ([@dependabot](https://github.com/dependabot))
+- Bump tar from 6.1.0 to 6.1.5 [#12](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/12) ([@dependabot](https://github.com/dependabot))
+- Bump normalize-url from 4.5.0 to 4.5.1 [#11](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/11) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.4.5 to 7.4.6 [#9](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/9) ([@dependabot](https://github.com/dependabot))
+- Fix security vulnerabilities [#5](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/5) ([@fcollonval](https://github.com/fcollonval))
+- Handle multiple servers [#4](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/4) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-link-share/graphs/contributors?from=2021-02-10&to=2021-09-13&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-link-share+involves%3Adependabot+updated%3A2021-02-10..2021-09-13&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-link-share+involves%3Afcollonval+updated%3A2021-02-10..2021-09-13&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-link-share+involves%3Ajtpio+updated%3A2021-02-10..2021-09-13&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.0
 
 ### Changes
 
 - Handle multiple servers: https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/4
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.2.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab-contrib/jupyterlab-link-share  |
| Branch  | main  |
| Version Spec | 0.2.1 |
| Since | 0.2.0 |