### PR TITLE
Use default user token when running under JupyterHub

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,15 @@ const plugin: JupyterFrontEndPlugin<void> = {
     commands.addCommand(CommandIDs.share, {
       label: trans.__('Share Jupyter Server Link'),
       execute: async () => {
-        const results: { token: string }[] = await requestAPI<any>('servers');
+        let results: { token: string }[];
+        if (PageConfig.getOption('hubUser') !== '') {
+          // We are running on a JupyterHub, so let's just use the token set in PageConfig.
+          // Any extra servers running on the server will still need to use this token anyway,
+          // as all traffic (including any to jupyter-server-proxy) needs this token.
+          results = [{ token: PageConfig.getToken() }];
+        } else {
+          results = await requestAPI<any>('servers');
+        }
 
         const links = results.map(server => {
           return URLExt.normalize(


### PR DESCRIPTION
When running under a JupyterHub, only the currently running
notebook server process is accessible from the browser (via
the proxy), so only the token set for the current server will work.
Any additional servers running (via jupyter-server-proxy) will
still need this token, so multiple servers running in a JupyterHub
(a currently unknown pattern) can't work anyway.

So when we are running in a JupyterHub, we just use the provided
token in the share URL. No network call is made.

Fixes https://github.com/jupyterlab-contrib/jupyterlab-link-share/issues/10