### PR TITLE
Automated Changelog Entry for 0.2.4 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.4
+
+([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-link-share/compare/v0.2.3...ffb6a15bbae346be5a491f0e36fd9811038bdd4b))
+
+### Enhancements made
+
+- Show correct URL when using retrolab [#27](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/27) ([@yuvipanda](https://github.com/yuvipanda))
+
+### Maintenance and upkeep improvements
+
+- Bump ansi-regex from 5.0.0 to 5.0.1 [#28](https://github.com/jupyterlab-contrib/jupyterlab-link-share/pull/28) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-link-share/graphs/contributors?from=2021-11-19&to=2021-11-19&type=c))
+
+[@dependabot](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-link-share+involves%3Adependabot+updated%3A2021-11-19..2021-11-19&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-link-share+involves%3Ajtpio+updated%3A2021-11-19..2021-11-19&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-link-share+involves%3Ayuvipanda+updated%3A2021-11-19..2021-11-19&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.3
 
 ([Full Changelog](https://github.com/jupyterlab-contrib/jupyterlab-link-share/compare/v0.2.2...1d6bfefc6c0cbfc45217381350dd84de4378fd6d))
@@ -19,8 +39,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlab-contrib/jupyterlab-link-share/graphs/contributors?from=2021-11-19&to=2021-11-19&type=c))
 
 [@dependabot](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-link-share+involves%3Adependabot+updated%3A2021-11-19..2021-11-19&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterlab-contrib%2Fjupyterlab-link-share+involves%3Ayuvipanda+updated%3A2021-11-19..2021-11-19&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.2.2
 


### PR DESCRIPTION
Automated Changelog Entry for 0.2.4 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab-contrib/jupyterlab-link-share  |
| Branch  | main  |
| Version Spec | 0.2.4 |
| Since | v0.2.3 |