### PR TITLE
Add .binder to the check manifest ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,4 @@ build_cmd = "build:prod"
 npm = ["jlpm"]
 
 [tool.check-manifest]
-ignore = ["*.json", "yarn.lock", ".*", "jupyterlab_link_share/labextension/**"]
+ignore = [".binder/**", "*.json", "yarn.lock", ".*", "jupyterlab_link_share/labextension/**"]


### PR DESCRIPTION
Follow-up to #30 to fix the CI check.